### PR TITLE
updated docs on theme install

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ Automagical css image gallery in [Hugo](https://gohugo.io/) using shortcodes, wi
 **(1)** Check out this repo into your `themes/` folder:
 
 ```
-git submodule add git@github.com:liwenyip/hugo-easy-gallery.git themes/easy-gallery
+git submodule add https://github.com/Darthagnon/hugo-easy-gallery.git themes/easy-gallery
+git submodule init
 ```
 
 **(2)** Then update your `./config.toml` to load the theme, for example:


### PR DESCRIPTION
when trying to install via theme component, the URL still points to the original location, not this updated fork! Also I believe one should follow up with `git submodule init` after adding a new submodule (but I'm still a beginner with git so maybe i'm wrong). anyway, tried to help out this really small bit!